### PR TITLE
Fix ldd sh mock in tests

### DIFF
--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -619,10 +619,15 @@ def test_FTL_detect_aarch64_no_errors(host):
     """
     # mock uname to return aarch64 platform
     mock_command("uname", {"-m": ("aarch64", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with aarch64 shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-aarch64.so.1", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-aarch64.so.1", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-aarch64.so.1", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -647,10 +652,15 @@ def test_FTL_detect_armv4t_no_errors(host):
     """
     # mock uname to return armv4t platform
     mock_command("uname", {"-m": ("armv4t", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with armv4t shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -675,10 +685,15 @@ def test_FTL_detect_armv5te_no_errors(host):
     """
     # mock uname to return armv5te platform
     mock_command("uname", {"-m": ("armv5te", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with ld-linux shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -704,9 +719,14 @@ def test_FTL_detect_armv6l_no_errors(host):
     # mock uname to return armv6l platform
     mock_command("uname", {"-m": ("armv6l", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -734,9 +754,14 @@ def test_FTL_detect_armv7l_no_errors(host):
     # mock uname to return armv7l platform
     mock_command("uname", {"-m": ("armv7l", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -763,10 +788,15 @@ def test_FTL_detect_armv8a_no_errors(host):
     """
     # mock uname to return armv8a platform
     mock_command("uname", {"-m": ("armv8a", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -789,8 +819,6 @@ def test_FTL_detect_x86_64_no_errors(host):
     """
     confirms only x86_64 package is downloaded for FTL engine
     """
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -813,8 +841,6 @@ def test_FTL_detect_unknown_no_errors(host):
     """confirms only generic package is downloaded for FTL engine"""
     # mock uname to return generic platform
     mock_command("uname", {"-m": ("mips", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh


### PR DESCRIPTION
Since "command" is a shell internal, it cannot be mocked, done via /usr/local/bin override. Since Debian containers ship without /bin => /usr/bin symlink, while all other containers do, the "ldd" mock needs to be applied for both paths.

This is to fix tests in https://github.com/pi-hole/pi-hole/pull/4907.